### PR TITLE
Add some tests for the TOTPAuthenticator, editorconfig and PSR-4 autoloader

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# For more information about the properties used in this file,
+# please see the EditorConfig documentation:
+# http://editorconfig.org
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,js,json,css,scss,feature,eslintrc}]
+indent_size = 2
+indent_style = space
+
+[composer.json]
+indent_size = 4

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,15 @@
+inherit: true
+
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
+checks:
+  php:
+    code_rating: true
+    duplication: true
+
+filter:
+  paths: [src/*, tests/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: trusty
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 7.0
+    - php: 7.1
       env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
       env: DB=PGSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: php
+
+dist: trusty
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPUNIT_TEST=1 PHPCS_TEST=1
+    - php: 7.0
+      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=PGSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+    - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
+    - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
+
+before_script:
+  # Init PHP
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini || true
+
+  # Install composer dependencies
+  - composer validate
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
+  - composer require silverstripe/recipe-core "$RECIPE_VERSION" --no-update
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+
+script:
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml tests; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src/ tests/; fi
+
+after_success:
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -1,37 +1,37 @@
 {
-  "name": "elliot-sawyer/totp-authenticator",
-  "description": "Enable 2FA authentication with TOTP",
-  "type": "silverstripe-vendormodule",
-  "license": "BSD-3-Clause",
-  "keywords": [
-    "silverstripe",
-    "2-factor",
-    "authentication",
-    "module",
-    "security"
-  ],
-  "authors": [
-    {
-      "name": "Elliot Sawyer"
+    "name": "elliot-sawyer/totp-authenticator",
+    "description": "Enable 2FA authentication with TOTP",
+    "type": "silverstripe-vendormodule",
+    "license": "BSD-3-Clause",
+    "keywords": [
+        "silverstripe",
+        "2-factor",
+        "authentication",
+        "module",
+        "security"
+    ],
+    "authors": [
+        {
+            "name": "Elliot Sawyer"
+        }
+    ],
+    "require": {
+        "firesphere/bootstrapmfa": "dev-master#f0fc8eb861b7e5dca3398dd9f59a382f5cdf5a23",
+        "endroid/qr-code": "3.2.12",
+        "lfkeitel/phptotp": "^1.0",
+        "silverstripe/framework": "^4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7"
+    },
+    "extra": {
+        "installer-name": "totp-authenticator",
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
+    "support": {
+        "issues": "https://github.com/elliot-sawyer/totp-authenticator/issues",
+        "source": "https://github.com/elliot-sawyer/totp-authenticator"
     }
-  ],
-  "require": {
-    "firesphere/bootstrapmfa": "dev-master#f0fc8eb861b7e5dca3398dd9f59a382f5cdf5a23",
-    "endroid/qr-code": "3.2.12",
-    "lfkeitel/phptotp": "^1.0",
-    "silverstripe/framework": "^4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^5.7"
-  },
-  "extra": {
-    "installer-name": "totp-authenticator",
-    "branch-alias": {
-      "dev-master": "1.0.x-dev"
-    }
-  },
-  "support": {
-    "issues": "https://github.com/elliot-sawyer/totp-authenticator/issues",
-    "source": "https://github.com/elliot-sawyer/totp-authenticator"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,13 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7"
     },
+    "autoload": {
+        "psr-4": {
+            "ElliotSawyer\\TOTPAuthenticator\\": "src/",
+            "ElliotSawyer\\TOTPAuthenticator\\Tests\\": "tests/"
+        }
+    },
     "extra": {
-        "installer-name": "totp-authenticator",
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "silverstripe/framework": "^4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,5 +39,7 @@
     "support": {
         "issues": "https://github.com/elliot-sawyer/totp-authenticator/issues",
         "source": "https://github.com/elliot-sawyer/totp-authenticator"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "firesphere/bootstrapmfa": "dev-master#f0fc8eb861b7e5dca3398dd9f59a382f5cdf5a23",
         "endroid/qr-code": "3.2.12",
         "lfkeitel/phptotp": "^1.0",
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4",
+        "silverstripe/siteconfig": "^4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2" >
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+    </rule>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
+    <testsuite name="Default">
+        <directory>tests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Providers/TOTPProvider.php
+++ b/src/Providers/TOTPProvider.php
@@ -45,7 +45,9 @@ class TOTPProvider extends BootstrapMFAProvider implements MFAProvider
                 $key = $totp->GenerateToken($secret);
                 $user_submitted_key = $token;
                 if ($user_submitted_key !== $key) {
-                    $result->addError(_t(self::class . '.INVALIDORMISSINGTOKEN', 'Invalid or missing second factor token'));
+                    $result->addError(
+                        _t(self::class . '.INVALIDORMISSINGTOKEN', 'Invalid or missing second factor token')
+                    );
                 } else {
                     return $this->member;
                 }

--- a/tests/Authenticators/TOTPAuthenticatorTest.php
+++ b/tests/Authenticators/TOTPAuthenticatorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace ElliotSawyer\TOTPAuthenticator\Tests\Authenticators;
+
+use ElliotSawyer\TOTPAuthenticator\TOTPAuthenticator;
+use Firesphere\BootstrapMFA\Authenticators\BootstrapMFAAuthenticator;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\Member;
+
+class TOTPAuthenticatorTest extends SapphireTest
+{
+    protected static $fixture_file = 'TOTPAuthenticatorTest.yml';
+
+    /**
+     * @var HTTPRequest
+     */
+    protected $request;
+
+    /**
+     * @var ValidationResult
+     */
+    protected $result;
+
+    /**
+     * @var TOTPAuthenticator
+     */
+    protected $authenticator;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->request = new HTTPRequest('GET', '/');
+        $this->request->setSession(new Session([]));
+
+        $this->result = new ValidationResult();
+
+        $this->authenticator = $this->getMockBuilder(TOTPAuthenticator::class)
+            ->setMethods(['getTokenFromTOTP'])
+            ->getMock();
+
+        // Assign a member ID from the fixtures to the session
+        $memberId = $this->idFromFixture(Member::class, 'admin_user');
+        $this->request->getSession()->set(BootstrapMFAAuthenticator::SESSION_KEY . '.MemberID', $memberId);
+    }
+
+    /**
+     * @todo is this actually desired behaviour?
+     */
+    public function testValidateTOTPReturnsValidationResultOnFailure()
+    {
+        $this->request->getSession()->clearAll();
+        $result = $this->authenticator->validateTOTP([], $this->request, $this->result);
+
+        $this->assertInstanceOf(ValidationResult::class, $result);
+    }
+
+    public function testValidateTOTPWithoutToken()
+    {
+        $this->authenticator->validateTOTP([], $this->request, $this->result);
+
+        $this->assertFalse($this->result->isValid(), 'Missing input data should cause an error');
+        $this->assertContains('No token sent', $this->result->serialize());
+    }
+
+    public function testValidateTOTPWithMismatchingKeyProvided()
+    {
+        $this->authenticator->validateTOTP(['token' => 'willnotmatch'], $this->request, $this->result);
+
+        $this->assertFalse($this->result->isValid(), 'Mismatching token should cause an error');
+        $this->assertContains('TOTP Failed', $this->result->serialize());
+    }
+
+    public function testValidateTOTPWithValidData()
+    {
+        $this->authenticator->expects($this->once())->method('getTokenFromTOTP')->willReturn('123456');
+        $memberToken = '123456';
+
+        $result = $this->authenticator->validateTOTP(['token' => $memberToken], $this->request, $this->result);
+
+        $this->assertTrue($this->result->isValid(), 'Valid TOTP token should validate successfully');
+        $this->assertInstanceOf(Member::class, $result, 'The member object should be returned on success');
+    }
+
+    /**
+     * @param string $configuredAlgorithm
+     * @param string $expected
+     * @dataProvider algorithmProvider
+     */
+    public function testGetAlgorithm($configuredAlgorithm, $expected)
+    {
+        Config::modify()->set(TOTPAuthenticator::class, 'algorithm', $configuredAlgorithm);
+
+        $this->assertSame($expected, TOTPAuthenticator::get_algorithm());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function algorithmProvider()
+    {
+        return [
+            'valid algorithm' => ['sha256', 'sha256'],
+            'another valid algorithm' => ['sha512', 'sha512'],
+            'invalid algorithm' => ['foo123', 'sha1'],
+        ];
+    }
+}

--- a/tests/Authenticators/TOTPAuthenticatorTest.yml
+++ b/tests/Authenticators/TOTPAuthenticatorTest.yml
@@ -1,0 +1,5 @@
+SilverStripe\Security\Member:
+  admin_user:
+    FirstName: Admin
+    Surname: User
+    Email: foo@example.com


### PR DESCRIPTION
* Add tests for TOTPAuthenticator and abstract out the logic to get the OTP from TOTP
* Add PSR-4 autoloader and remove obsolete installer-name
* Add standard editorconfig and reformat composer.json
* Add Travis, phpcs and phpunit config
* Add missing siteconfig dependency
* Add Scrutinizer configuration

This PR abstracts out the logic for getting the OTP from `Totp` so it can be mocked for unit testing

A start to #17

Resolves #19 